### PR TITLE
Fix toPrintable removing ascii spaces which are printable.

### DIFF
--- a/common/src/main/java/com/ongres/scram/common/util/UsAsciiUtils.java
+++ b/common/src/main/java/com/ongres/scram/common/util/UsAsciiUtils.java
@@ -43,7 +43,7 @@ public class UsAsciiUtils {
             int c = (int) chr;
             if (c < 0 || c >= 127) {
                 throw new IllegalArgumentException("value contains character '" + chr + "' which is non US-ASCII");
-            } else if (c > 32) {
+            } else if (c >= 32) {
                 printable[i++] = chr;
             }
         }

--- a/common/src/test/java/com/ongres/scram/common/stringprep/StringPreparationTest.java
+++ b/common/src/test/java/com/ongres/scram/common/stringprep/StringPreparationTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 
 public class StringPreparationTest {
-    private static final String[] ONLY_NON_PRINTABLE_STRINGS = new String[] { " ", (char) 13 + "", (char) 13 + "   " };
+    private static final String[] ONLY_NON_PRINTABLE_STRINGS = new String[] { (char) 13 + "", (char) 13 + "\n\n" };
 
     @Test
     public void doNormalizeNullEmpty() {

--- a/common/src/test/java/com/ongres/scram/common/util/UsAsciiUtilsTest.java
+++ b/common/src/test/java/com/ongres/scram/common/util/UsAsciiUtilsTest.java
@@ -66,7 +66,7 @@ public class UsAsciiUtilsTest {
     @Test
     public void toPrintableNonPrintable() {
         String[] original = new String[] { " u ",   "a" + (char) 12,    (char) 0 + "ttt" + (char) 31 };
-        String[] expected = new String[] { "u",     "a",                "ttt" };
+        String[] expected = new String[] { " u ",     "a",                "ttt" };
 
         for(int i = 0; i < original.length; i++) {
             assertEquals("", expected[i], UsAsciiUtils.toPrintable(original[i]));


### PR DESCRIPTION
Space is a printable character. Scram is a dependency pgjdbc uses to implement scram authentication. Pgjdbc normalizes string using this StringPreparations.NO_PREPARATION by default. This causes spaces in passwords to be stripped causing authentication failures due to wrong hash. [RFC 4013](https://tools.ietf.org/html/rfc4013) does not prohibit ASCII spaces. 