### PR TITLE
feat(crypto): add support for SCRAM-SHA3-512 mechanisms

### DIFF
--- a/scram-common/src/main/java/com/ongres/scram/common/ScramMechanism.java
+++ b/scram-common/src/main/java/com/ongres/scram/common/ScramMechanism.java
@@ -79,7 +79,15 @@ public enum ScramMechanism {
   /**
    * SCRAM-SHA-512-PLUS mechanism.
    */
-  SCRAM_SHA_512_PLUS("SCRAM-SHA-512-PLUS", "SHA-512", "HmacSHA512");
+  SCRAM_SHA_512_PLUS("SCRAM-SHA-512-PLUS", "SHA-512", "HmacSHA512"),
+  /**
+   * SCRAM-SHA3-512 mechanism.
+   */
+  SCRAM_SHA3_512("SCRAM-SHA3-512", "SHA3-512", "HmacSHA3-512"),
+  /**
+   * SCRAM-SHA3-512-PLUS mechanism.
+   */
+  SCRAM_SHA3_512_PLUS("SCRAM-SHA3-512-PLUS", "SHA3-512", "HmacSHA3-512");
 
   private static final @Unmodifiable Map<String, ScramMechanism> BY_NAME_MAPPING =
       Arrays.stream(values())

--- a/scram-common/src/test/java/com/ongres/scram/common/Gs2AttributeValueTest.java
+++ b/scram-common/src/test/java/com/ongres/scram/common/Gs2AttributeValueTest.java
@@ -8,11 +8,8 @@ package com.ongres.scram.common;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.ongres.scram.common.Gs2AttributeValue;
-import com.ongres.scram.common.Gs2Attributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;

--- a/scram-common/src/test/java/com/ongres/scram/common/Gs2HeaderTest.java
+++ b/scram-common/src/test/java/com/ongres/scram/common/Gs2HeaderTest.java
@@ -8,8 +8,6 @@ package com.ongres.scram.common;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.ongres.scram.common.Gs2CbindFlag;
-import com.ongres.scram.common.Gs2Header;
 import org.junit.jupiter.api.Test;
 
 class Gs2HeaderTest {

--- a/scram-common/src/test/java/com/ongres/scram/common/HiFunctionTest.java
+++ b/scram-common/src/test/java/com/ongres/scram/common/HiFunctionTest.java
@@ -12,9 +12,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +28,6 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 
 import com.ongres.scram.common.exception.ScramInterruptedException;
-import com.ongres.scram.common.exception.ScramRuntimeException;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,13 +39,11 @@ class HiFunctionTest {
   private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   // Character sets for different edge cases
-  private static final String ALPHANUMERIC =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  private static final String ALPHANUMERIC = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
   private static final String SPECIAL = "!@#$%^&*()-_=+[{]}\\|;:'\",.<>/?`~ ";
   private static final String UNICODE_EMOJI = "🚀🔥🛡️🔑";
   private static final String UNICODE_EXTENDED = "こんにちは世界"; // "Hello World" in Japanese
-  private static final String COMBINED_POOL =
-      ALPHANUMERIC + SPECIAL + UNICODE_EXTENDED + UNICODE_EMOJI;
+  private static final String COMBINED_POOL = ALPHANUMERIC + SPECIAL + UNICODE_EXTENDED + UNICODE_EMOJI;
   private static final int[] VALID_CODE_POINTS = COMBINED_POOL.codePoints().toArray();
 
   private static char[] generateRandom(int length) {
@@ -176,6 +175,29 @@ class HiFunctionTest {
     assertNotNull(caught, "Expected an exception, but the task completed normally.");
     assertInstanceOf(ScramInterruptedException.class, caught,
         "Expected ScramInterruptedException but got: " + caught.getClass().getName());
+  }
+
+  @Test
+  void testHmacSHA3_512() throws Exception {
+    // Derived key generated via "golang.org/x/crypto/pbkdf2"
+    String expectedHex = "AVe/93um8jge6rPdfKvlV11zTpETcH56COQ+GToe4F3tv+99LYkIYYY4rLFbjbAz+6mdbZXVBbphDmgN2o3LSQ==";
+    byte[] expected = Base64.getDecoder().decode(expectedHex);
+
+    // Gracefully skip on JVMs (like Java 8) that lack native SHA-3 support
+    Mac mac;
+    try {
+      mac = Mac.getInstance("HmacSHA3-512");
+    } catch (NoSuchAlgorithmException e) {
+      Assumptions.abort("Skipping test: JVM does not support HmacSHA3-512");
+      return;
+    }
+
+    char[] password = "my_super_secret_password".toCharArray();
+    byte[] salt = "my_random_salt_value".getBytes(StandardCharsets.UTF_8);
+    int iterations = 100_000;
+    byte[] actual = CryptoUtil.hi(mac, password, salt, iterations);
+
+    assertArrayEquals(expected, actual, "Hi mismatch for HmacSHA3-512");
   }
 
 }

--- a/scram-common/src/test/java/com/ongres/scram/common/ScramFunctionsTest.java
+++ b/scram-common/src/test/java/com/ongres/scram/common/ScramFunctionsTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Locale;
 

--- a/scram-common/src/test/java/com/ongres/scram/common/UsAsciiUtilsTest.java
+++ b/scram-common/src/test/java/com/ongres/scram/common/UsAsciiUtilsTest.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.ongres.scram.common.UsAsciiUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;


### PR DESCRIPTION
Introduce the SCRAM-SHA3-512 and SCRAM-SHA3-512-PLUS SASL mechanisms to support modern NIST SHA-3 hashing standards, providing higher cryptographic resilience against length-extension attacks.

- Register SCRAM-SHA3-512 and -PLUS variants in SASL mechanism listings.
- Add test vectors validating PBKDF2 iteration parity for SHA3-512.
- Implement conditional JUnit assumptions to ensure safe compilation and test execution across varying baseline JVM provider environments.

Closes https://github.com/ongres/scram/issues/23 