### PR TITLE
fix(client): resolve regression when passing pre-computed keys

### DIFF
--- a/scram-client/src/main/java/com/ongres/scram/client/ClientFinalProcessor.java
+++ b/scram-client/src/main/java/com/ongres/scram/client/ClientFinalProcessor.java
@@ -8,6 +8,8 @@ package com.ongres.scram.client;
 import static com.ongres.scram.common.util.Preconditions.checkNotEmpty;
 import static com.ongres.scram.common.util.Preconditions.checkNotNull;
 
+import java.util.Arrays;
+
 import com.ongres.scram.common.ClientFinalMessage;
 import com.ongres.scram.common.ClientFirstMessage;
 import com.ongres.scram.common.ScramFunctions;
@@ -39,6 +41,9 @@ final class ClientFinalProcessor {
   private final ServerFirstMessage serverFirstMessage;
   private String authMessage;
 
+  /**
+   * Primary constructor utilizing pre-computed cryptographic keys.
+   */
   private ClientFinalProcessor(ScramMechanism scramMechanism, byte[] clientKey,
       byte[] storedKey, byte[] serverKey, ClientFirstMessage clientFirstMessage,
       ServerFirstMessage serverFirstMessage) {
@@ -50,12 +55,31 @@ final class ClientFinalProcessor {
     this.serverFirstMessage = serverFirstMessage;
   }
 
+  /**
+   * Constructs a processor using pre-computed Client and Server keys.
+   * The Stored Key is automatically derived.
+   *
+   * @param scramMechanism The SCRAM mechanism.
+   * @param clientKey The pre-computed client key material.
+   * @param serverKey The pre-computed server key material.
+   * @param clientFirstMessage The client-first-message contextual state.
+   * @param serverFirstMessage The server-first-message contextual state.
+   */
   ClientFinalProcessor(ScramMechanism scramMechanism, byte[] clientKey, byte[] serverKey,
       ClientFirstMessage clientFirstMessage, ServerFirstMessage serverFirstMessage) {
-    this(scramMechanism, clientKey, ScramFunctions.storedKey(scramMechanism, clientKey),
-        serverKey, clientFirstMessage, serverFirstMessage);
+    this(scramMechanism, clientKey.clone(), ScramFunctions.storedKey(scramMechanism, clientKey),
+        serverKey.clone(), clientFirstMessage, serverFirstMessage);
   }
 
+  /**
+   * Constructs a processor using a pre-computed salted password.
+   * Client, Server, and Stored keys are derived directly from the salted password.
+   *
+   * @param scramMechanism The SCRAM mechanism.
+   * @param saltedPassword The pre-computed salted password material.
+   * @param clientFirstMessage The client-first-message contextual state.
+   * @param serverFirstMessage The server-first-message contextual state.
+   */
   ClientFinalProcessor(ScramMechanism scramMechanism, byte[] saltedPassword,
       ClientFirstMessage clientFirstMessage, ServerFirstMessage serverFirstMessage) {
     this(
@@ -65,15 +89,40 @@ final class ClientFinalProcessor {
         clientFirstMessage, serverFirstMessage);
   }
 
+  /**
+   * Constructs a processor from raw credentials, performing PBKDF2 salt derivation.
+   *
+   * @param scramMechanism The SCRAM mechanism.
+   * @param stringPreparation The SASLprep normalization configuration rules.
+   * @param password The cleartext password array.
+   * @param salt The salt bytes received from the server.
+   * @param clientFirstMessage The client-first-message contextual state.
+   * @param serverFirstMessage The server-first-message contextual state.
+   */
   ClientFinalProcessor(ScramMechanism scramMechanism, StringPreparation stringPreparation,
       char[] password, byte[] salt, ClientFirstMessage clientFirstMessage,
       ServerFirstMessage serverFirstMessage) {
-    this(scramMechanism,
-        ScramFunctions.saltedPassword(scramMechanism, stringPreparation, password, salt,
-            serverFirstMessage.getIterationCount()),
-        clientFirstMessage, serverFirstMessage);
+    this.scramMechanism = scramMechanism;
+    this.clientFirstMessage = clientFirstMessage;
+    this.serverFirstMessage = serverFirstMessage;
+
+    byte[] saltedPassword = ScramFunctions.saltedPassword(
+        scramMechanism, stringPreparation, password, salt, serverFirstMessage.getIterationCount());
+    try {
+      this.clientKey = ScramFunctions.clientKey(scramMechanism, saltedPassword);
+      this.serverKey = ScramFunctions.serverKey(scramMechanism, saltedPassword);
+      this.storedKey = ScramFunctions.storedKey(scramMechanism, this.clientKey);
+    } finally {
+      // Wipe saltedPassword immediately
+      Arrays.fill(saltedPassword, (byte) 0);
+    }
   }
 
+  /**
+   * Generates and caches the authMessage metadata string required for signing logic if not already present.
+   *
+   * @param cbindData The channel binding payload data bytes.
+   */
   private void generateAndCacheAuthMessage(byte[] cbindData) {
     if (null == this.authMessage) {
       this.authMessage = ScramFunctions.authMessage(clientFirstMessage, serverFirstMessage, cbindData);
@@ -84,8 +133,8 @@ final class ClientFinalProcessor {
    * Generates the SCRAM representation of the client-final-message, including the given
    * channel-binding data.
    *
-   * @param cbindData The bytes of the channel-binding data
-   * @return The message
+   * @param cbindData The bytes of the channel-binding data, or null if no channel binding is utilized.
+   * @return The constructed ClientFinalMessage object.
    */
   @NotNull
   ClientFinalMessage clientFinalMessage(byte @Nullable [] cbindData) {
@@ -101,27 +150,36 @@ final class ClientFinalProcessor {
   }
 
   /**
-   * Receive and process the server-final-message. Server SCRAM signatures is verified.
+   * Receive and process the server-final-message. The server's signature is explicitly verified.
    *
-   * @param serverFinalMessage The received server-final-message
-   * @throws ScramParseException If the message is not a valid server-final-message
-   * @throws ScramServerErrorException If the server-final-message contained an error
-   * @throws ScramInvalidServerSignatureException If the server signature is invalid
-   * @throws IllegalArgumentException If the message is null or empty
+   * @param serverFinalMessage The received raw server-final-message text line string.
+   * @return The parsed and validated ServerFinalMessage instance representation.
+   * @throws ScramParseException If the string composition fails structure parsing rules.
+   * @throws ScramServerErrorException If the server-final-message contains an error attribute message.
+   * @throws ScramInvalidServerSignatureException If the verified computed signature fails validation matches.
+   * @throws IllegalArgumentException If the input parameter message value evaluates null or empty.
    */
   @NotNull
   ServerFinalMessage receiveServerFinalMessage(@NotNull String serverFinalMessage)
       throws ScramParseException, ScramServerErrorException, ScramInvalidServerSignatureException {
     checkNotEmpty(serverFinalMessage, "serverFinalMessage");
 
-    ServerFinalMessage message = ServerFinalMessage.parseFrom(serverFinalMessage);
-    if (message.isError()) {
-      throw new ScramServerErrorException(message.getServerError());
+    try {
+      ServerFinalMessage message = ServerFinalMessage.parseFrom(serverFinalMessage);
+      if (message.isError()) {
+        throw new ScramServerErrorException(message.getServerError());
+      }
+      if (!ScramFunctions.verifyServerSignature(
+          scramMechanism, serverKey, authMessage, message.getVerifier())) {
+        throw new ScramInvalidServerSignatureException("Invalid SCRAM server signature");
+      }
+      return message;
+    } finally {
+      // Wipe the sensitive data, even if an exception was thrown above
+      Arrays.fill(clientKey, (byte) 0);
+      Arrays.fill(storedKey, (byte) 0);
+      Arrays.fill(serverKey, (byte) 0);
     }
-    if (!ScramFunctions.verifyServerSignature(
-        scramMechanism, serverKey, authMessage, message.getVerifier())) {
-      throw new ScramInvalidServerSignatureException("Invalid SCRAM server signature");
-    }
-    return message;
   }
+
 }

--- a/scram-client/src/main/java/com/ongres/scram/client/ServerFirstProcessor.java
+++ b/scram-client/src/main/java/com/ongres/scram/client/ServerFirstProcessor.java
@@ -7,7 +7,6 @@ package com.ongres.scram.client;
 
 import static com.ongres.scram.common.util.Preconditions.checkNotEmpty;
 import static com.ongres.scram.common.util.Preconditions.checkNotNull;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Base64;
 
@@ -56,7 +55,7 @@ final class ServerFirstProcessor {
         scramMechanism,
         stringPreparation,
         checkNotEmpty(password, "password"),
-        Base64.getDecoder().decode(serverFirstMessage.getSalt().getBytes(UTF_8)),
+        Base64.getDecoder().decode(serverFirstMessage.getSalt()),
         clientFirstMessage,
         serverFirstMessage);
   }

--- a/scram-client/src/test/java/com/example/ScramClientTest.java
+++ b/scram-client/src/test/java/com/example/ScramClientTest.java
@@ -7,12 +7,18 @@ package com.example;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Base64;
 
 import com.ongres.scram.client.ScramClient;
 import com.ongres.scram.common.ClientFinalMessage;
+import com.ongres.scram.common.ScramFunctions;
+import com.ongres.scram.common.ScramMechanism;
+import com.ongres.scram.common.StringPreparation;
+import com.ongres.scram.common.exception.ScramInvalidServerSignatureException;
+import com.ongres.scram.common.exception.ScramServerErrorException;
 import com.ongres.scram.common.util.TlsServerEndpoint;
 import org.junit.jupiter.api.Test;
 
@@ -108,6 +114,93 @@ class ScramClientTest {
 
     assertDoesNotThrow(
         () -> scramSession.serverFinalMessage("v=sz/isCwVSUn/TBWeYABz6WaoZIcfsui9NPaJCoxxAjY="));
+  }
+
+  @Test
+  void preComputedKeysTest() throws Exception {
+    ScramMechanism mechanism = ScramMechanism.SCRAM_SHA_256;
+    byte[] salt = Base64.getDecoder().decode("W22ZaJ0SNY7soEsUEjb6gQ==");
+    int iterationCount = 4096;
+
+    // Pre-computed clientKey/serverKey
+    byte[] saltedPassword = ScramFunctions.saltedPassword(
+        mechanism, StringPreparation.SASL_PREPARATION, "pencil".toCharArray(), salt, iterationCount
+    );
+    byte[] clientKey = ScramFunctions.clientKey(mechanism, saltedPassword);
+    byte[] serverKey = ScramFunctions.serverKey(mechanism, saltedPassword);
+
+    // Initialize the client utilizing the optimized pre-computed keys tracking option
+    ScramClient scramSession = ScramClient.builder()
+        .advertisedMechanisms(Arrays.asList("SCRAM-SHA-256"))
+        .username("user")
+        .clientAndServerKey(clientKey, serverKey)
+        .nonceSupplier(() -> "rOprNGfwEbeRWgbNEkqO")
+        .build();
+
+    // Verify step processing yields identical proofs and matches execution vectors exactly
+    assertEquals("SCRAM-SHA-256", scramSession.getScramMechanism().getName());
+    assertEquals("n,,n=user,r=rOprNGfwEbeRWgbNEkqO", scramSession.clientFirstMessage().toString());
+
+    assertDoesNotThrow(
+        () -> scramSession.serverFirstMessage(
+            "r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,"
+                + "s=W22ZaJ0SNY7soEsUEjb6gQ==,"
+                + "i=4096"));
+
+    ClientFinalMessage clientFinalMessage = scramSession.clientFinalMessage();
+    assertEquals(
+        "c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0"
+            + ",p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ=",
+        clientFinalMessage.toString());
+
+    assertDoesNotThrow(
+        () -> scramSession.serverFinalMessage("v=6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4="));
+  }
+
+  @Test
+  void throwScramInvalidServerSignatureException() {
+    ScramClient scramSession = ScramClient.builder()
+        .advertisedMechanisms(Arrays.asList("SCRAM-SHA-256"))
+        .username("postgres")
+        .password("pencil".toCharArray())
+        .channelBinding(TlsServerEndpoint.TLS_SERVER_END_POINT, CBIND_DATA)
+        .nonceSupplier(() -> "1q^MGrWUi{etW+H7(#k431kB")
+        .build();
+    scramSession.clientFirstMessage();
+
+    assertDoesNotThrow(
+        () -> scramSession.serverFirstMessage(
+            "r=1q^MGrWUi{etW+H7(#k431kBdAr3CWX7B6houDP4f7Z2XEpZ,"
+                + "s=Fgh8JU2AlRjBHUsIU/GgtQ==,"
+                + "i=10"));
+    scramSession.clientFinalMessage();
+
+    // The server returns an ivalid signature
+    assertThrows(ScramInvalidServerSignatureException.class,
+        () -> scramSession.serverFinalMessage("v=Fgh8JU2AlRjBHUsIU/GgtQ=="));
+  }
+
+  @Test
+  void throwScramServerErrorException() {
+    ScramClient scramSession = ScramClient.builder()
+        .advertisedMechanisms(Arrays.asList("SCRAM-SHA-256", "SCRAM-SHA-512"))
+        .username("postgres")
+        .password("pencil".toCharArray())
+        .channelBinding(TlsServerEndpoint.TLS_SERVER_END_POINT, CBIND_DATA)
+        .nonceSupplier(() -> "1q^MGrWUi{etW+H7(#k431kB")
+        .build();
+
+    scramSession.clientFirstMessage();
+    assertDoesNotThrow(
+        () -> scramSession.serverFirstMessage(
+            "r=1q^MGrWUi{etW+H7(#k431kBdAr3CWX7B6houDP4f7Z2XEpZ,"
+                + "s=Fgh8JU2AlRjBHUsIU/GgtQ==,"
+                + "i=10"));
+    scramSession.clientFinalMessage();
+
+    // Simulate that the server returns an error
+    assertThrows(ScramServerErrorException.class,
+        () -> scramSession.serverFinalMessage("e=invalid-proof"));
   }
 
 }

--- a/scram-client/src/test/java/com/ongres/scram/client/ScramBuilderTest.java
+++ b/scram-client/src/test/java/com/ongres/scram/client/ScramBuilderTest.java
@@ -9,15 +9,18 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
 
 import com.ongres.scram.common.ClientFinalMessage;
+import com.ongres.scram.common.ClientFirstMessage;
 import com.ongres.scram.common.ScramFunctions;
 import com.ongres.scram.common.ScramMechanism;
 import com.ongres.scram.common.StringPreparation;
-import com.ongres.scram.common.exception.ScramRuntimeException;
 import org.junit.jupiter.api.Test;
 
 class ScramBuilderTest {
@@ -135,6 +138,52 @@ class ScramBuilderTest {
             .build());
 
     assertEquals("Either a bare or -PLUS mechanism must be present", assertThrows.getMessage());
+  }
+
+  @Test
+  void testSecureRandomAlgorithmProvider() {
+    assertDoesNotThrow(() -> ScramClient.builder()
+        .advertisedMechanisms(Arrays.asList("SCRAM-SHA-256"))
+        .username("user")
+        .password("pencil".toCharArray())
+        .secureRandomAlgorithmProvider("DRBG", null)
+        .build());
+  }
+
+  @Test
+  void testSecureRandomAlgorithmProviderThrows() {
+    assertThrows(IllegalArgumentException.class, () -> ScramClient.builder()
+        .advertisedMechanisms(Arrays.asList("SCRAM-SHA-256"))
+        .username("user")
+        .password("pencil".toCharArray())
+        .secureRandomAlgorithmProvider("DRBG", "invalid")
+        .build());
+  }
+
+  @Test
+  void testEmptyMechanisms() {
+    IllegalArgumentException assertThrows = assertThrows(IllegalArgumentException.class,
+        () -> ScramClient.builder()
+            .advertisedMechanisms(Arrays.asList())
+            .username("user")
+            .password("pencil".toCharArray())
+            .build());
+
+    assertEquals("Argument 'scramMechanisms' is not valid", assertThrows.getMessage());
+  }
+
+  @Test
+  void testAuthzid() {
+    ScramClient scramClient = ScramClient.builder()
+        .advertisedMechanisms(Arrays.asList("SCRAM-SHA-256"))
+        .username("user")
+        .password("pencil".toCharArray())
+        .authzid("postgres")
+        .build();
+
+    ClientFirstMessage clientFirstMessage = scramClient.clientFirstMessage();
+    assertEquals("postgres", clientFirstMessage.getGs2Header().getAuthzid());
+    assertTrue(clientFirstMessage.toString().startsWith("n,a=postgres,n=user"));
   }
 
 }


### PR DESCRIPTION
Fixes a bug where pre-computed keys were prematurely zeroed out by the state machine's orchestration loop. Cloning the keys during constructor initialization safely isolates internal data tracking so proofs compute flawlessly.

Also adds more memory hardening and optimizations:
- Guarantees `clientKey`, `storedKey`, and `serverKey` are wiped with zeros inside a try-finally block immediately after server signature verification.
- Adds a try-finally sequence to clear `saltedPassword` allocations right after sub-keys are derived from raw credentials.
- Optimizes Base64 salt decoding to bypass redundant byte allocations.
- Adds comprehensive test coverage for pre-computed paths, server error parsing, and custom SecureRandom selection options.